### PR TITLE
Updated Data Imports to reference Aggregate Root

### DIFF
--- a/src/covidify/data_prep.py
+++ b/src/covidify/data_prep.py
@@ -21,7 +21,8 @@ from string import capwords
 from difflib import get_close_matches
 from datetime import datetime, date, time 
 
-from covidify.sources import github, wiki
+from covidify.sources import agg_data_sources as sourceData 
+
 from covidify.config import REPO, TMP_FOLDER, TMP_GIT, DATA
 from covidify.utils.utils import replace_arg_score
 

--- a/src/covidify/data_prep.py
+++ b/src/covidify/data_prep.py
@@ -21,6 +21,7 @@ from string import capwords
 from difflib import get_close_matches
 from datetime import datetime, date, time 
 
+#import/use aggregate root instead of git and wiki itself
 from covidify.sources import agg_data_sources as sourceData 
 
 from covidify.config import REPO, TMP_FOLDER, TMP_GIT, DATA
@@ -41,13 +42,13 @@ if '_' in country:
 
 if country == 'Global':
     country = None
-
+#use reference dataFetch to access root to fetch Git data
 if source == 'JHU':
-    df = github.get()
-    
+    dataFetch = sourceData.getDataGit()
+#use reference dataFetch to access root to fetch Wiki data    
 elif source == 'wiki':
     print('Apologies, the wikipedia source is not ready yet - getting github data')
-    df = github.get()
+    dataFetch = sourceData.getDataWiki()
     
 
 

--- a/src/covidify/list_countries.py
+++ b/src/covidify/list_countries.py
@@ -9,15 +9,19 @@ import sys
 import click
 import covidify
 import numpy as np
-from covidify.sources import github
+
+#import/use aggregate root instead of git and wiki itself
+from covidify.sources import agg_data_sources as sourceData 
+
 from covidify.config import SCRIPT
 
 def get_countries():
     print('Getting available countries...')
-    df = github.get()
-    df = df[df.confirmed > 0]
+    #use reference dataFetch to access root to fetch Git data
+    dataFetch = sourceData.getDataGit()
+    dataFetch = dataFetch[dataFetch.confirmed > 0]
 
-    countries = sorted(list(set(df.country.values)))
+    countries = sorted(list(set(dataFetch.country.values)))
 
     for a,b,c in zip(countries[::3],countries[1::3],countries[2::3]):
         print('{:<30}{:<30}{:<}'.format(a,b,c))


### PR DESCRIPTION
Updated the Imports. Instead of importing Git and Wiki individually, it now Imports and  uses the Aggregate root for data fetch.

Updated data fetch variables to reference and use aggregate root created for both Git and Wiki in _data_prep.py_ and _list_countries.py_

This will only allow outside objects to reference the root for data access rather than referencing anything inside the aggregate boundary, such as Git, and Wiki individually. 

Some methods to access data not completely implemented, however good naming convention is used to describe what actions methods are meant to complete