### PR TITLE
Adding Bridge pattern to data ingestion

### DIFF
--- a/src/covidify/builder.py
+++ b/src/covidify/builder.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from abc import ABC, abstractmethod, abstractproperty
+from typing import Any
+import covidify.data_visualization as visualization
+
+class ReportBuilder(ABC):
+
+    @abstractproperty
+    def report(self) -> None:
+        pass
+
+    @abstractmethod
+    def produce_graph(self) -> None:
+        pass
+
+    @abstractmethod
+    def produce_table(self) -> None:
+        pass
+
+class ConcreteReportBuilder(ReportBuilder):
+
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self._report = Report1()
+
+    @property
+    def report(self) -> Report1:
+        report = self._report
+        self.reset()
+        return report
+
+    def produce_graph(self) -> None:
+        print("Creating Graph...")
+        self._report.add(visualization.create_graph())
+
+    def produce_table(self) -> None:
+        print("Creating Table...")
+        self._report.add(visualization.create_table())
+
+class Report1():
+
+    def __init__(self) -> None:
+        self.parts = []
+
+    def add(self, part: Any) -> None:
+        self.parts.append(part)
+
+    def list_parts(self) -> None:
+        print(f"Test Output: {', '.join(self.parts)}", end="")
+
+class Director:
+
+    def __init__(self) -> None:
+        self._builder = None
+
+    @property
+    def builder(self) -> ReportBuilder:
+        return self._builder
+
+    @builder.setter
+    def builder(self, builder: ReportBuilder) -> None:
+        self._builder = builder
+
+    def build_graph(self) -> None:
+        self.builder.produce_graph()
+
+    def build_table(self) -> None:
+        self.builder.produce_table()
+
+    def build_table_garph(self) -> None:
+        self.builder.produce_table()
+        self.builder.produce_graph()

--- a/src/covidify/dataBridge.py
+++ b/src/covidify/dataBridge.py
@@ -1,0 +1,63 @@
+import matplotlib.image as mpimg
+import pandas as pd
+from PIL import Image
+from __future__ import annotations
+from abc import ABC, abstractmethod 
+
+#Abstract data injestion
+class AbstractDataInjestion:
+
+    def __init__(self, implementation: Implementation) -> None:
+        self.implementation = implementation
+
+    def injestion(self) -> str:
+        return (f"Reading .png:\n" f"{self.implementation.injestion_implementation()}")
+
+#1st Extended abstract data injestion, reads .tsv file
+class csvDataInjestion(AbstractDataInjestion):
+    def injestion(self) -> str:
+        return (f"Reading .csv:\n"f"{self.implementation.injestion_implementation()}")
+
+#2nd Extended abstract data injestion, reads .csv file
+class jpgDataInjestion(AbstractDataInjestion):
+    def injestion(self) -> str:
+        return (f"Reading .jpg:\n"f"{self.implementation.injestion_implementation()}")
+
+class Implementation(ABC):
+    @abstractmethod
+    def injestion_implementation(self) -> str:
+        pass
+
+class pngConcreteImplementation(Implementation):
+    def injestion_implementation(self) -> str:
+        img = mpimg.imread('/image_path.png')
+        print("Done Reading png!\n")
+        return img
+
+class csvConcreteImplementation(Implementation):
+    def injestion_implementation(self) -> str:
+        dt = pd.read_csv(r'/data.csv')
+        print("Done Reading csv!\n")
+        return dt
+
+class jpgConcreteImplementation(Implementation):
+    def injestion_implementation(self) -> str:
+        img = Image.open("/image_path.jpg")
+        print("Done reading jpg!\n")
+        return img
+
+def client_code(abstraction: AbstractDataInjestion) -> None:
+    print(abstraction.injestion(), end="")
+
+if __name__ == "__main__":
+    implementation = pngConcreteImplementation()
+    abstraction = AbstractDataInjestion(implementation)
+    client_code(abstraction)
+
+    implementation = csvConcreteImplementation()
+    abstraction = csvDataInjestion(implementation)
+    client_code(abstraction)
+
+    implementation = jpgConcreteImplementation()
+    abstraction = jpgDataInjestion(implementation)
+    client_code(abstraction)


### PR DESCRIPTION
The bridge pattern is used to separate the interface of a class from it’s implementation. Then we can have multiple implementations, one to ingest .csv files, one to ingest .dtb files, … etc, and we won't have to worry about it breaking since bridge allows for implementation to be switched at runtime. Then there can be many implementations for many file formats. Then with the bridges adapter, we know the output will work with the rest of Covidify.

By adding the bridge pattern to Covidify I have made it more universal as many more file types may easily be ingested.

